### PR TITLE
fix: use one method for referencing private link hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,90 @@ module "teras_module" {
   source  = "..."
   version = "..."
 
-  variable_a = "..."
-  varialbe_b = "..."
+  resource_group_name = "rg-data-dev-uks"
+  resource_suffix     = "data-dev-uks"
+
+  data_lake_account_name       = module.data_lake.data_lake_account_name
+  data_lake_adls_filesystem_id = module.data_lake.data_lake_adls_filesystem_id
+  synapse_aad_administrator    = {
+    username  = "example@ascent.io"
+    object_id = "00000000-0000-0000-0000-000000000000"
+    tenant_id = "00000000-0000-0000-0000-000000000000"
+  }
 }
 ```
 
 | :scroll: Note: Defaults |
 |----------|
 | See [inputs](#inputs) for a complete list of input variables and their defaults. |
+
+| :scroll: Note: Data Lake |
+|----------|
+| This module expects an existing data lake. Consider using the [teras-synapse-data-lake]() module to provision a data lake and pass the outputs from that module into this module. |
+
+Example deployment with dedicated SQL pool:
+```
+module "teras_module" {
+  source  = "..."
+  version = "..."
+
+  resource_group_name = "rg-data-dev-uks"
+  resource_suffix     = "data-dev-uks"
+
+  data_lake_account_name       = module.data_lake.data_lake_account_name
+  data_lake_adls_filesystem_id = module.data_lake.data_lake_adls_filesystem_id
+  synapse_aad_administrator    = {
+    username  = "example@ascent.io"
+    object_id = "00000000-0000-0000-0000-000000000000"
+    tenant_id = "00000000-0000-0000-0000-000000000000"
+  }
+
+  enable_dedicated_sql_pool  = true
+  synapse_dedicated_sql_pool = {
+    name      = "sqlpool"
+    sku       = "DW100c"
+    collation = "SQL_Latin1_General_CP1_CI_AS"
+  }
+}
+```
+
+| :warning: Warning: Cost |
+|----------|
+| Dedicated SQL pools are expensive. Use the optional `synapse_dedicated_sql_pool` variable to tune the pool configuration to your needs. |
+
+Example deployment with custom Spark pool configuration:
+
+```
+module "teras_module" {
+  source  = "..."
+  version = "..."
+
+  resource_group_name = "rg-data-dev-uks"
+  resource_suffix     = "data-dev-uks"
+
+  data_lake_account_name       = module.data_lake.data_lake_account_name
+  data_lake_adls_filesystem_id = module.data_lake.data_lake_adls_filesystem_id
+  synapse_aad_administrator    = {
+    username  = "example@ascent.io"
+    object_id = "00000000-0000-0000-0000-000000000000"
+    tenant_id = "00000000-0000-0000-0000-000000000000"
+  }
+
+  synapse_spark_pool = {
+    name                     = "sparkpool"
+    auto_pause_delay_minutes = 15
+    max_node_count           = 12
+    min_node_count           = 3
+    size                     = "Medium"
+    version                  = "3.2"
+    requirements             = file("requirements.txt")
+  }
+}
+```
+
+| :scroll: Note: Spark Pool Requirements |
+|----------|
+| Synapse Spark pools are deployed with some Python packages available by default |
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/locals.tf
+++ b/locals.tf
@@ -30,15 +30,12 @@ locals {
     "SynapseWorkspace" = {
       endpoint_name      = "pe-syn-ws-${var.resource_suffix}"
       subresource_names  = ["Web"]
-      target_resource_id = azurerm_synapse_private_link_hub.synapse[0].id
+      target_resource_id = one(azurerm_synapse_private_link_hub.synapse).id
     }
   }
-  synapse_private_endpoints_to_create = var.enable_private_networking ? [
-    "SynapseDedicatedSql",
-    "SynapseDevelopment",
-    "SynapseServerlessSql",
-    "SynapseWorkspace"
-  ] : []
+
+  # Only create private endpoints if private networking is enabled
+  synapse_private_endpoints_to_create = var.enable_private_networking ? keys(local.synapse_private_endpoints) : []
 
   # Reduce RBAC data structure into a flat format for dynamic role assignment
   synapse_role_assignments = flatten([


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updates to module documentation only)

## Description

Change the way private endpoint targets are calculated for optional resources such as Synapse Private Link Hub.

### Added Resources
- _None_

### Updated Resources
- _None_

### Removed Resources
- _None_

### Other Changes
- _None_

## Checklist

Please confirm that you have completed the following tasks by putting an `x` in the checkboxes:

- [ ] I have updated the README file to reflect any changes made to the module as necessary.
- [ ] I have added or updated relevant documentation (e.g. comments in the code) to explain the changes made.
- [ ] I have added or updated tests to ensure that the changes work as expected.
- [ ] I have followed the module's existing style and naming conventions.
- [ ] I have confirmed that the changes do not introduce any linting or formatting errors.
- [ ] I have confirmed that the changes do not introduce any security vulnerabilities.
- [ ] I have confirmed that the changes do not cause any backward compatibility issues.

## Related Issues

Please list any related issues or pull requests that are associated with this change, if applicable.

## Additional Information

If there's any additional information that would be helpful for the reviewer, please provide it here.
